### PR TITLE
[UI] Fix hyperlink on about screen to match visible text

### DIFF
--- a/PivxWallet/BRSettingsViewController.m
+++ b/PivxWallet/BRSettingsViewController.m
@@ -184,7 +184,7 @@
 
 - (IBAction)about:(id)sender
 {
-    SFSafariViewController * safariViewController = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:@"https://www.dash.org/forum/topic/ios-dash-digital-wallet-support.112/"]];
+    SFSafariViewController * safariViewController = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:@"https://www.github.com/PIVX-Project/PIVX-iOS/"]];
     [self presentViewController:safariViewController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
clicking on the hyperlink now properly opens a web page at the
correct URL.