### PR TITLE
Bump protocol version

### DIFF
--- a/PivxWallet/BRPeer.m
+++ b/PivxWallet/BRPeer.m
@@ -40,8 +40,8 @@
 #define MAX_MSG_LENGTH     0x02000000
 #define MAX_GETDATA_HASHES 50000
 #define ENABLED_SERVICES   0     // we don't provide full blocks to remote nodes
-#define PROTOCOL_VERSION   70914
-#define MIN_PROTO_VERSION  70914 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
+#define PROTOCOL_VERSION   70916
+#define MIN_PROTO_VERSION  70916 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
 #define LOCAL_HOST         0x7f000001
 #define CONNECT_TIMEOUT    3.0
 #define MEMPOOL_TIMEOUT    5.0


### PR DESCRIPTION
Required to maintain connectivity once the core 3.3.0 version is locked in.