### PR TITLE
Add detection for iPhone XR/XS MAX

### DIFF
--- a/PivxWallet/BRRootViewController.m
+++ b/PivxWallet/BRRootViewController.m
@@ -130,7 +130,9 @@
     
     CGFloat y = self.view.frame.size.height - 114;
     if ([[Utils deviceType] isEqualToString:@"iphoneX"]) {
-        y = y - 22;
+        y = y - 42;
+    } else if ([[Utils deviceType] isEqualToString:@"iphoneXRSMAX"]) {
+        y = y - 42;
     }
     CGFloat width = self.view.frame.size.width;
     self.buttonContainer = [[UIView alloc] initWithFrame:CGRectMake(0, y, width, 50)];

--- a/PivxWallet/PivxUtils/Utils.swift
+++ b/PivxWallet/PivxUtils/Utils.swift
@@ -138,18 +138,27 @@ class Utils: NSObject {
     
     @objc static func deviceType()->String{
         if UIDevice().userInterfaceIdiom == .phone {
-            switch UIScreen.main.nativeBounds.height {
-            case 1136:
+            let SCREEN_WIDTH = UIScreen.main.bounds.size.width
+            let SCREEN_HEIGHT = UIScreen.main.bounds.size.height
+            let SCREEN_MAX_LENGTH = max(SCREEN_WIDTH, SCREEN_HEIGHT)
+            switch SCREEN_MAX_LENGTH {
+            case 568.0:
                 print("iPhone 5 or 5S or 5C")
                 return "iPhone5"
-            case 1334:
+            case 667.0:
                 print("iPhone 6/6S/7/8")
                 return "iphone6"
-            case 2208:
+            case 736.0:
+                print("iPhone 6+/7+/8+")
                 return "iphone6plus"
-            case 2436:
+            case 812.0:
+                print("iPhone X")
                 return "iphoneX"
+            case 896.0:
+                print("iPhone XR/XS/Max")
+                return "iphoneXRSMAX"
             default:
+                print(UIScreen.main.nativeBounds.height)
                 return ""
             }
         }


### PR DESCRIPTION
Fixes #10 by adding new detection for iPhone XS/XR/XS MAX and adjusting the position of the RECEIVE/SEND buttons on the main wallet view.

Before (iPhone XR / XS Max): 
<img src="https://user-images.githubusercontent.com/7393257/59747509-dbc7d180-922d-11e9-85d8-8c3f345e5155.png" height="600">

After (iPhone XR / XS Max):
<img src="https://user-images.githubusercontent.com/7393257/59747612-0dd93380-922e-11e9-9be4-a353d52cf0fe.png" height="600">

Note: I purposely added some extra padding at the bottom for all *X* models so as to not have the software "home" button overlap

