### PR TITLE
Show actual app version in menu UI

### DIFF
--- a/PivxWallet/PivxControllers/MenuController.swift
+++ b/PivxWallet/PivxControllers/MenuController.swift
@@ -18,6 +18,7 @@ class MenuController: BaseController {
     
     @IBOutlet weak var syncImageView: UIImageView!
     @IBOutlet weak var syncLabel: UILabel!
+    @IBOutlet weak var versionLabel: UILabel!
     @IBOutlet weak var cotainerViewHeightConstraint: NSLayoutConstraint!
     var optionSelected:Int = 1
     
@@ -44,6 +45,13 @@ class MenuController: BaseController {
             selector: #selector(self.syncFailed),
             name: Notification.Name.BRPeerManagerSyncFailedNotification,
             object: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let dictionary = Bundle.main.infoDictionary!
+        let version = dictionary["CFBundleShortVersionString"] as! String
+        versionLabel.text = "v" + version
     }
     
     /**

--- a/PivxWallet/PivxNibs/Controllers/Menu.xib
+++ b/PivxWallet/PivxNibs/Controllers/Menu.xib
@@ -17,6 +17,7 @@
                 <outlet property="titleLabel2" destination="YdU-m1-Uls" id="28Z-2d-1ee"/>
                 <outlet property="titleLabel3" destination="e1l-rE-EGa" id="Ax3-NN-NDW"/>
                 <outlet property="titleLabel4" destination="kjj-IR-Hfc" id="SMg-is-hEZ"/>
+                <outlet property="versionLabel" destination="exs-BN-k2H" id="gGI-XV-pFo"/>
                 <outlet property="view" destination="iN0-l3-epB" id="Mv6-lJ-zfw"/>
             </connections>
         </placeholder>


### PR DESCRIPTION
Rather than have a static text label that needs manual updating, use the
app bundle version programmatically.