### PR TITLE
[Build] Add basic TravisCI support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,12 @@
+disabled_rules:
+    - colon
+    - comma
+    - identifier_name
+    - type_name
+excluded:
+    - Pods
+force_cast:
+    severity: warning
+line_length:
+    warning: 200
+    error: 400

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+language: objective-c
+osx_image: xcode10.1
+cache: cocoapods
+stages:
+    - lint
+    - test
+env:
+    - LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
+before_install:
+    - gem install cocoapods
+    - gem install xcpretty -N
+before_script:
+    - pod install
+script:
+    - set -o pipefail
+    - xcodebuild -workspace PivxWallet.xcworkspace -scheme pivxwallet -destination "platform=iOS Simulator,name=$DEVICE,OS=$OS" ONLY_ACTIVE_ARCH=NO | xcpretty -c
+after_script:
+    - echo $TRAVIS_COMMIT_RANGE
+    - echo $TRAVIS_COMMIT_LOG
+jobs:
+    include:
+
+        - stage: lint
+          name: 'Swift Lint'
+          env:
+          cache: false
+          before_install:
+          before_script:
+          script:
+              - swiftlint
+
+        - stage: test
+          name: 'iPhone 6 [iOS 9]'
+          env:
+            - DEVICE="iPhone 6"
+            - OS=9.1
+
+        - stage: test
+          name: 'iPhone 7 [iOS 10.1]'
+          env:
+            - DEVICE="iPhone 7"
+            - OS=10.1
+
+        - stage: test
+          name: 'iPhone X [iOS 12.1]'
+          env:
+            - DEVICE="iPhone X"
+            - OS=12.1
+
+        - stage: test
+          name: 'iPad Pro (12.9-inch) (2nd Generation) [iOS 12.1]'
+          env:
+            - DEVICE="iPad Pro (12.9-inch) (2nd generation)"
+            - OS=12.1
+

--- a/PivxWallet.xcodeproj/xcshareddata/xcschemes/pivxwallet.xcscheme
+++ b/PivxWallet.xcodeproj/xcshareddata/xcschemes/pivxwallet.xcscheme
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D567A5064CC31414035042F39B74F90"
+               BuildableName = "Pods_pivxwallet.framework"
+               BlueprintName = "Pods-pivxwallet"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1D826447CE01EBC17A3E6A9873E2F6EE"
+               BuildableName = "SlideMenuControllerSwift.framework"
+               BlueprintName = "SlideMenuControllerSwift"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "75D5F3BD191EC270004AB296"
+               BuildableName = "PIVX.app"
+               BlueprintName = "pivxwallet"
+               ReferencedContainer = "container:PivxWallet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "75D5F3E4191EC270004AB296"
+               BuildableName = "PivxWalletTests.xctest"
+               BlueprintName = "PivxWalletTests"
+               ReferencedContainer = "container:PivxWallet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "31D68B4F1C23B6C10030FAAA"
+               BuildableName = "PivxWalletUITests.xctest"
+               BlueprintName = "PivxWalletUITests"
+               ReferencedContainer = "container:PivxWallet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "75D5F3BD191EC270004AB296"
+            BuildableName = "PIVX.app"
+            BlueprintName = "pivxwallet"
+            ReferencedContainer = "container:PivxWallet.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "75D5F3BD191EC270004AB296"
+            BuildableName = "PIVX.app"
+            BlueprintName = "pivxwallet"
+            ReferencedContainer = "container:PivxWallet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "75D5F3BD191EC270004AB296"
+            BuildableName = "PIVX.app"
+            BlueprintName = "pivxwallet"
+            ReferencedContainer = "container:PivxWallet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This adds basic support for build testing on TravisCI.

A linter stage is included to lint the `.swift` files, but it is initially set to for warnings instead of errors. The intent behind this is that we can fixup the linter warnings, then switch to defaulting to returning errors in the future.

Build stages include builds for a range of iOS devices and OS versions, with the minimum supported device/os being iPhone 6/iOS 9.