### PR TITLE
[Net] Bump protocol version to be compatible with v3.4.0 core wallet

### DIFF
--- a/PivxWallet/BRPeer.m
+++ b/PivxWallet/BRPeer.m
@@ -40,8 +40,8 @@
 #define MAX_MSG_LENGTH     0x02000000
 #define MAX_GETDATA_HASHES 50000
 #define ENABLED_SERVICES   0     // we don't provide full blocks to remote nodes
-#define PROTOCOL_VERSION   70916
-#define MIN_PROTO_VERSION  70916 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
+#define PROTOCOL_VERSION   70917
+#define MIN_PROTO_VERSION  70917 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
 #define LOCAL_HOST         0x7f000001
 #define CONNECT_TIMEOUT    3.0
 #define MEMPOOL_TIMEOUT    5.0


### PR DESCRIPTION
No protocol level changes are needed on the app side for this.