### PR TITLE
Fix PIV numpad input

### DIFF
--- a/PivxWallet/BRWalletManager.m
+++ b/PivxWallet/BRWalletManager.m
@@ -258,7 +258,12 @@ typedef BOOL (^PinVerificationBlock)(NSString * _Nonnull currentPin,BRWalletMana
                                       stringByReplacingCharactersInRange:[self.dashFormat.positiveFormat rangeOfString:@"#"]
                                       withString:@"-#"];
     self.dashFormat.currencyCode = @"PIVX";
-    self.dashFormat.currencySymbol = PIVX NARROW_NBSP;
+    if (@available(iOS 13.0, *)) {
+        self.dashFormat.currencySymbol = PIVX;
+    }
+    else {
+        self.dashFormat.currencySymbol = PIVX NARROW_NBSP;
+    }
     self.dashFormat.maximumFractionDigits = 8;
     self.dashFormat.minimumFractionDigits = 0; // iOS 8 bug, minimumFractionDigits now has to be set after currencySymbol
     self.dashFormat.maximum = @(MAX_MONEY/(int64_t)pow(10.0, self.dashFormat.maximumFractionDigits));
@@ -271,7 +276,11 @@ typedef BOOL (^PinVerificationBlock)(NSString * _Nonnull currentPin,BRWalletMana
                                                  stringByReplacingCharactersInRange:[self.dashFormat.positiveFormat rangeOfString:@"#"]
                                                  withString:@"-#"];
     self.dashSignificantFormat.currencyCode = @"PIVX";
-    self.dashSignificantFormat.currencySymbol = PIVX NARROW_NBSP;
+    if (@available(iOS 13.0, *)) {
+        self.dashSignificantFormat.currencySymbol = PIVX;
+    } else {
+        self.dashSignificantFormat.currencySymbol = PIVX NARROW_NBSP;
+    }
     self.dashSignificantFormat.usesSignificantDigits = TRUE;
     self.dashSignificantFormat.minimumSignificantDigits = 1;
     self.dashSignificantFormat.maximumSignificantDigits = 6;
@@ -287,7 +296,11 @@ typedef BOOL (^PinVerificationBlock)(NSString * _Nonnull currentPin,BRWalletMana
                                          stringByReplacingCharactersInRange:[self.bitcoinFormat.positiveFormat rangeOfString:@"#"]
                                          withString:@"-#"];
     self.bitcoinFormat.currencyCode = @"BTC";
-    self.bitcoinFormat.currencySymbol = BTC NARROW_NBSP;
+    if (@available(iOS 13.0, *)) {
+        self.bitcoinFormat.currencySymbol = BTC;
+    } else {
+        self.bitcoinFormat.currencySymbol = BTC NARROW_NBSP;
+    }
     self.bitcoinFormat.maximumFractionDigits = 8;
     self.bitcoinFormat.minimumFractionDigits = 0; // iOS 8 bug, minimumFractionDigits now has to be set after currencySymbol
     self.bitcoinFormat.maximum = @(MAX_MONEY/(int64_t)pow(10.0, self.bitcoinFormat.maximumFractionDigits));


### PR DESCRIPTION
iOS 13 changed the spacing in a way that PIV value inputs on the keypad
were broken. This fixes it.

Closes #29