### PR TITLE
Switch to CoinGecko API

### DIFF
--- a/PivxWallet/BRWalletManager.m
+++ b/PivxWallet/BRWalletManager.m
@@ -52,7 +52,7 @@
 #define BITCOIN_TICKER_URL  @"https://bitpay.com/rates"
 // PIVX is not in Poloniex yet ;P
 //#define POLONIEX_TICKER_URL  @"https://poloniex.com/public?command=returnOrderBook&currencyPair=BTC_PIVX&depth=1"
-#define COINMARKETCAP_TICKER_URL @"https://api.coinmarketcap.com/v1/ticker/pivx/"
+#define COINGECKO_TICKER_URL @"https://api.coingecko.com/api/v3/coins/pivx?localization=false&tickers=false&community_data=false&developer_data=false&sparkline=false"
 #define TICKER_REFRESH_TIME 60.0
 
 #define SEED_ENTROPY_LENGTH   (256/8)
@@ -1331,7 +1331,7 @@ bool responder = false;
     if (self.reachability.currentReachabilityStatus == NotReachable) return;
     
     
-    NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:COINMARKETCAP_TICKER_URL]
+    NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:COINGECKO_TICKER_URL]
                                          cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
     
     [[[NSURLSession sharedSession] dataTaskWithRequest:req
@@ -1350,15 +1350,16 @@ bool responder = false;
                                              if (now > self.secureTime) [defs setDouble:now forKey:SECURE_TIME_KEY];
                                          }
                                          NSError *error = nil;
-                                         NSArray *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-                                         NSDictionary* jsonData = json.firstObject;
-                                         NSString * lastPrice = [jsonData objectForKey:@"price_btc"];
+                                         NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+                                         NSDictionary *marketData = json[@"market_data"];
+                                         NSDictionary *priceData = marketData[@"current_price"];
+                                         NSNumber * lastPrice = priceData[@"btc"];
                                          NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
                                          NSLocale *usa = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
                                          numberFormatter.locale = usa;
                                          numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
                                          NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
-                                         NSNumber *lastTradePriceNumber = [numberFormatter numberFromString:lastPrice];
+                                         NSNumber *lastTradePriceNumber = [numberFormatter numberFromString:lastPrice.stringValue];
                                          [defs setObject:lastTradePriceNumber forKey:POLONIEX_DASH_BTC_PRICE_KEY];
                                          [defs setObject:[NSDate date] forKey:POLONIEX_DASH_BTC_UPDATE_TIME_KEY];
                                          [defs synchronize];

--- a/PivxWallet/Base.lproj/Main.storyboard
+++ b/PivxWallet/Base.lproj/Main.storyboard
@@ -2018,7 +2018,7 @@ This app is open source:</string>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="D4H-hd-LsX">
                                         <rect key="frame" x="100" y="174.99999999999997" width="214" height="36"/>
                                         <string key="text">Exchange rate data provided by
-coinmarketcap.com</string>
+coingecko.com</string>
                                         <fontDescription key="fontDescription" type="system" weight="light" pointSize="15"/>
                                         <nil key="highlightedColor"/>
                                     </label>

--- a/PivxWallet/en.lproj/Localizable.strings
+++ b/PivxWallet/en.lproj/Localizable.strings
@@ -246,6 +246,12 @@
 "Exit" = "Exit";
 
 /* No comment provided by engineer. */
+"Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Face ID spending limit" = "Face ID spending limit";
+
+/* No comment provided by engineer. */
 "Failed wallet update" = "Failed wallet update";
 
 /* No comment provided by engineer. */

--- a/PivxWallet/en.lproj/Main.strings
+++ b/PivxWallet/en.lproj/Main.strings
@@ -41,8 +41,8 @@
 /* Class = "UILabel"; text = "Start/Recover Another Wallet"; ObjectID = "D1b-HB-lKH"; */
 "D1b-HB-lKH.text" = "Start/Recover Another Wallet";
 
-/* Class = "UILabel"; text = "Exchange rate data provided by\ncoinmarketcap.com"; ObjectID = "D4H-hd-LsX"; */
-"D4H-hd-LsX.text" = "Exchange rate data provided by\ncoinmarketcap.com";
+/* Class = "UILabel"; text = "Exchange rate data provided by\ncoingecko.com"; ObjectID = "D4H-hd-LsX"; */
+"D4H-hd-LsX.text" = "Exchange rate data provided by\ncoingecko.com";
 
 /* Class = "UIButton"; normalTitle = "New wallet"; ObjectID = "dOa-zm-TDG"; */
 "dOa-zm-TDG.normalTitle" = "New wallet";


### PR DESCRIPTION
CoinMarketCap has discontinued their free public API, which was
resulting in the inability to get the fiat valuation.

This switches the API request over to CoinGecko.